### PR TITLE
Fixed mistype in the Rakefile for iOS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,6 +71,6 @@ end
 namespace :build do
   namespace :ios do
     Rake::Task['openssl:ios:all'].invoke
-    Rake::Taks['sqlcipher:ios:all'].invoke
+    Rake::Task['sqlcipher:ios:all'].invoke
   end
 end


### PR DESCRIPTION
I used this repo to build sqlcipher for an iOS app I am working on.  I had to fix a mistype in the Rakefile to get it to work.
